### PR TITLE
CompiledTest::getClassName() returns non-empty string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "webignition/basil-compiler-models": "^5.2",
         "webignition/basil-loader": ">=5.1,<6",
         "webignition/basil-models": ">=6.3,<7",
-        "webignition/php-basil-compilable-source-factory": "^4.0",
+        "webignition/php-basil-compilable-source-factory": ">=4.1,<5",
         "webignition/stubble": "^0.16.0"
     },
     "require-dev": {

--- a/src/Model/CompiledTest.php
+++ b/src/Model/CompiledTest.php
@@ -6,9 +6,12 @@ namespace SmartAssert\Compiler\Model;
 
 class CompiledTest
 {
+    /**
+     * @param non-empty-string $className
+     */
     public function __construct(
-        private string $code,
-        private string $className
+        private readonly string $code,
+        private readonly string $className
     ) {
     }
 
@@ -17,6 +20,9 @@ class CompiledTest
         return $this->code;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getClassName(): string
     {
         return $this->className;


### PR DESCRIPTION
Fixes #101